### PR TITLE
Disable all automated workflows

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -16,10 +16,6 @@
 
 name: Graphs CI
 on:
-  schedule:
-    - cron: "0 0 * * *"
-  repository_dispatch:
-    types: [graphs]
   workflow_dispatch:
 jobs:
   release:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -16,10 +16,6 @@
 
 name: Response Time CI
 on:
-  schedule:
-    - cron: "0 23 * * *"
-  repository_dispatch:
-    types: [response_time]
   workflow_dispatch:
 jobs:
   release:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -16,11 +16,6 @@
 
 name: Setup CI
 on:
-  push:
-    paths:
-      - ".upptimerc.yml"
-  repository_dispatch:
-    types: [setup]
   workflow_dispatch:
 jobs:
   release:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -16,10 +16,6 @@
 
 name: Static Site CI
 on:
-  schedule:
-    - cron: "0 1 * * *"
-  repository_dispatch:
-    types: [static_site]
   workflow_dispatch:
 jobs:
   release:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -16,10 +16,6 @@
 
 name: Summary CI
 on:
-  schedule:
-    - cron: "0 0 * * *"
-  repository_dispatch:
-    types: [summary]
   workflow_dispatch:
 jobs:
   release:

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -16,10 +16,6 @@
 
 name: Update Template CI
 on:
-  schedule:
-    - cron: "0 0 * * *"
-  repository_dispatch:
-    types: [update_template]
   workflow_dispatch:
 jobs:
   release:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -16,10 +16,6 @@
 
 name: Updates CI
 on:
-  schedule:
-    - cron: "0 3 * * *"
-  repository_dispatch:
-    types: [updates]
   workflow_dispatch:
 jobs:
   release:

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -16,10 +16,6 @@
 
 name: Uptime CI
 on:
-  schedule:
-    - cron: "*/5 * * * *"
-  repository_dispatch:
-    types: [uptime]
   workflow_dispatch:
 jobs:
   release:


### PR DESCRIPTION
This PR disables all automated GitHub Actions workflows for the uptime-monitoring repository.

**Context:**
- This repository is no longer actively used for uptime monitoring
- The CI workflows (especially 'Uptime CI') have been failing repeatedly
- Automated triggers (schedules, push events, repository dispatch) have been removed

**Changes:**
- Modified all 8 workflow files in `.github/workflows/`
- Removed `schedule` triggers (daily/hourly cron jobs)
- Removed `repository_dispatch` triggers
- Removed `push` triggers from setup workflow
- Kept `workflow_dispatch` so workflows can still be triggered manually if needed

**Result:**
- No workflows will run automatically
- All workflows remain available for manual execution via GitHub UI
- This will stop the recurring CI failures

All workflows can be re-enabled in the future if needed by reverting this PR.